### PR TITLE
docs: :memo: small documentation addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,14 +340,18 @@ hooks:
       - echo 'hi, we are within the prepr phase'
       - echo 'maybe you want to change the code a bit and do another push before creating the pr'
 ```
+
 ## Labels creation
+
 By default, generated PRs will be labeled with the `template_sync` label.
 If that label doesn't exist in your repository, it will be created automatically unless you specify your own existing labels.
 Associating a label with the generated PRs helps keeping track of them and allows for features like automatic PR cleanup.
 
 ## Pull request cleanup
+
 Depending on your way of working, you may end up with multiple pull requests related to template syncing pointing to the same branch.
-If you want to avoid this situation, you can instruct this action to clean up older PRs pointing to the same branch (search based on labels).
+If you want to avoid this situation, you can instruct this action to clean up older PRs pointing to the same branch (search based on labels defined with the `pr_labels` config parameter).
+:warning: this feature will close all pull requests with labels configured with `pr_labels` config parameter.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ Associating a label with the generated PRs helps keeping track of them and allow
 ## Pull request cleanup
 
 Depending on your way of working, you may end up with multiple pull requests related to template syncing pointing to the same branch.
-If you want to avoid this situation, you can instruct this action to clean up older PRs pointing to the same branch (search based on labels defined with the `pr_labels` config parameter).
+If you want to avoid this situation, you can instruct this action to clean up older PRs (search based on labels defined with the `pr_labels` config parameter).
 :warning: this feature will close all pull requests with labels configured with `pr_labels` config parameter.
 
 ## Troubleshooting


### PR DESCRIPTION
# Description

Hi @kevin-aude just a small documentation addon and small markdownlint fix.
I tested the label creation (-> it works) but not the prune of old PRs.

If all is fine from your side, I will merge your PR into the main.

Thanks  a lot for the feature :rocket: 

## Remark

For automation please see [closing-issues-using-keywords](
    https://help.github.com/en/articles/closing-issues-using-keywords)
